### PR TITLE
Fix deprecated method call.

### DIFF
--- a/src/Assetic/Extension/Twig/AsseticTokenParser.php
+++ b/src/Assetic/Extension/Twig/AsseticTokenParser.php
@@ -118,7 +118,7 @@ class AsseticTokenParser extends AbstractTokenParser
                 $attributes[$key] = $stream->expect(Token::STRING_TYPE)->getValue();
             } else {
                 $token = $stream->getCurrent();
-                throw new SyntaxError(sprintf('Unexpected token "%s" of value "%s"', Token::typeToEnglish($token->getType()), $token->getValue()), $token->getLine(), $stream->getFilename());
+                throw new SyntaxError(sprintf('Unexpected token "%s" of value "%s"', Token::typeToEnglish($token->getType()), $token->getValue()), $token->getLine(), $stream->getSourceContext());
             }
         }
 


### PR DESCRIPTION
Call  `Twig\TokenStream::getSourceContext()` instead of `Twig\TokenStream::getFilename()` which is deprecated since twig 1.27 and removed in twig 2.0